### PR TITLE
azure-functions 1.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-
 # About azure-functions
+
 ===========================
 
 Feedstock license: [BSD-3-Clause](https://github.com/AnacondaRecipes/azure-functions/blob/main/LICENSE.txt)
@@ -10,9 +10,8 @@ Package license: MIT
 
 Summary: Azure Functions for Python
 
-
 Installing azure-functions
-================
+==========================
 
 `azure-functions` can be installed with:
 
@@ -32,9 +31,8 @@ Terminology
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
 
-
 Updating azure-functions-feedstock
-========================
+==================================
 
 If you would like to improve the azure-functions recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
@@ -42,14 +40,14 @@ your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build.
 
 In order to produce a uniquely identifiable distribution:
- * If the version of a package **is not** being increased, please add or increase
-   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
- * If the version of a package **is** being increased, please remember to return
-   the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
-   back to 0.
+
+* If the version of a package **is not** being increased, please add or increase
+  the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string).
+* If the version of a package **is** being increased, please remember to return
+  the [``build/number``](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string)
+  back to 0.
 
 Feedstock Maintainers
 =====================
 
-* [@AddYourGitHubIdHere](https://github.com/AddYourGitHubIdHere/)
-
+* [@skupr-anaconda](https://github.com/AddYourGitHubIdHere/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,10 @@ test:
     - requests >=2,<3
   commands:
     - pip check
-    - pytest -vv
+    # Skip test_http_response_accepts_http_enums because of the upstream bug:
+    # AttributeError: 'TestHTTP' object has no attribute 'assertEquals'.
+    # There should be 'assertEqual' instead.
+    - pytest -vv -k "not test_http_response_accepts_http_enums"
 
 about:
   home: https://azure.microsoft.com/en-us/products/functions/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,13 +41,13 @@ test:
 about:
   home: https://azure.microsoft.com/en-us/products/functions/
   doc_url: https://learn.microsoft.com/en-us/azure/azure-functions/
-  dev_url: https://github.com/Azure/Azure-Functions/
+  dev_url: https://github.com/Azure/azure-functions-python-library
   summary: Azure Functions for Python
-  description: Azure Functions for Python
+  description: Azure Functions Python SDK
   license: MIT
   license_family: MIT
   license_file: LICENSE
 
 extra:
   recipe-maintainers:
-    - AddYourGitHubIdHere
+    - skupr-anaconda


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3496](https://anaconda.atlassian.net/browse/PKG-3496)
- release-notes: https://github.com/Azure/azure-functions-python-library/releases
- license: https://github.com/Azure/azure-functions-python-library/blob/dev/LICENSE
- requirements-tagged: https://github.com/Azure/azure-functions-python-library/blob/1.19.0/setup.py

### Explanation of changes:

- Create a new feedstock from scratch.
- Skip `test_http_response_accepts_http_enums` because `AttributeError: 'TestHTTP' object has no attribute 'assertEquals'. Did you mean: 'assertEqual'?`. FYI, `assertEquals` is deprecated from `Python >=2.7 and >=3.3`, see the table here https://docs.python.org/2/library/unittest.html#unittest.TestCase.debug

### Notes:

- `Azure-Functions` isn't only one Python package but a bunch of the repositories https://github.com/orgs/Azure/repositories?language=&q=functions&sort=&type=all&page=1. Now, I'm building the requested package https://github.com/Azure/azure-functions-python-library/tree/1.19.0. Should we build other packages even if they are not direct dependencies? 

[PKG-3496]: https://anaconda.atlassian.net/browse/PKG-3496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ